### PR TITLE
Fix support for Enums

### DIFF
--- a/spec/enums/as_argument.graphql
+++ b/spec/enums/as_argument.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  episodeToString(episode: Episode!): String
 }
 
 "A String Value"

--- a/spec/enums/as_argument_array.graphql
+++ b/spec/enums/as_argument_array.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  episodesToString(episodes: [Episode!]!): String!
 }
 
 "A String Value"

--- a/spec/enums/as_argument_array_spec.cr
+++ b/spec/enums/as_argument_array_spec.cr
@@ -1,0 +1,47 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsArgumentArray
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def episodes_to_string(episodes : Array(Episode)) : String
+      episodes.join(", ")
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema" do
+    got = GraphQL::Schema.new(TestEnumsAsArgumentArray::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_argument_array.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+
+  it "returns the correct value" do
+    GraphQL::Schema.new(TestEnumsAsArgumentArray::Query.new).execute(
+      %(
+        query {
+          result: episodesToString(episodes: [JEDI,NEWHOPE] )
+        }
+      )
+    ).should eq (
+      {
+        "data" => {
+          "result" => "JEDI, NEWHOPE",
+        },
+      }
+    ).to_json
+  end
+end

--- a/spec/enums/as_argument_array_spec.cr
+++ b/spec/enums/as_argument_array_spec.cr
@@ -21,6 +21,13 @@ module TestEnumsAsArgumentArray
   end
 end
 
+class GraphqlRequest
+  include JSON::Serializable
+
+  @[JSON::Field(key: "variables")]
+  property variables : Hash(String, JSON::Any)?
+end
+
 describe GraphQL::Enum do
   it "Enums generates correct schema" do
     got = GraphQL::Schema.new(TestEnumsAsArgumentArray::Query.new).document.to_s.strip
@@ -40,6 +47,27 @@ describe GraphQL::Enum do
       {
         "data" => {
           "result" => "JEDI, NEWHOPE",
+        },
+      }
+    ).to_json
+  end
+
+  it "returns the correct value with variable" do
+    request = {"variables" => {"e" => ["EMPIRE","NEWHOPE"]}}.to_json
+
+    graphql_request = GraphqlRequest.from_json(request)
+
+    GraphQL::Schema.new(TestEnumsAsArgumentArray::Query.new).execute(
+      %(
+        query($e: [Episode!]!) {
+          result: episodesToString(episodes: $e)
+        }
+      ),
+      graphql_request.variables
+    ).should eq (
+      {
+        "data" => {
+          "result" => "EMPIRE, NEWHOPE",
         },
       }
     ).to_json

--- a/spec/enums/as_argument_optional.graphql
+++ b/spec/enums/as_argument_optional.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  episodeToString(episode: Episode): String!
 }
 
 "A String Value"

--- a/spec/enums/as_argument_optional_spec.cr
+++ b/spec/enums/as_argument_optional_spec.cr
@@ -1,0 +1,49 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsOptionalArgument
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def episode_to_string(episode : Episode?) : String
+      return "No Episode Given" if episode.nil?
+
+      episode.to_s
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema for optional arguments" do
+    got = GraphQL::Schema.new(TestEnumsAsOptionalArgument::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_argument_optional.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+
+  it "returns the correct value" do
+    GraphQL::Schema.new(TestEnumsAsOptionalArgument::Query.new).execute(
+      %(
+        query {
+          result: episodeToString
+        }
+      )
+    ).should eq (
+      {
+        "data" => {
+          "result" => "No Episode Given",
+        },
+      }
+    ).to_json
+  end
+end

--- a/spec/enums/as_argument_spec.cr
+++ b/spec/enums/as_argument_spec.cr
@@ -1,0 +1,47 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsArgument
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def episode_to_string(episode : Episode) : String?
+      episode.to_s
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema" do
+    got = GraphQL::Schema.new(TestEnumsAsArgument::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_argument.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+
+  it "returns the correct value" do
+    GraphQL::Schema.new(TestEnumsAsArgument::Query.new).execute(
+      %(
+        query {
+          result: episodeToString(episode: JEDI)
+        }
+      )
+    ).should eq (
+      {
+        "data" => {
+          "result" => "JEDI",
+        },
+      }
+    ).to_json
+  end
+end

--- a/spec/enums/as_return.graphql
+++ b/spec/enums/as_return.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  aEpisode: Episode!
 }
 
 "A String Value"

--- a/spec/enums/as_return_array.graphql
+++ b/spec/enums/as_return_array.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  episodes: [Episode!]!
 }
 
 "A String Value"

--- a/spec/enums/as_return_array_spec.cr
+++ b/spec/enums/as_return_array_spec.cr
@@ -1,0 +1,31 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsArrayReturn
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def episodes : Array(Episode)
+      [Episode::NEWHOPE, Episode::EMPIRE, Episode::JEDI]
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema" do
+    got = GraphQL::Schema.new(TestEnumsAsArrayReturn::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_return_array.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+end

--- a/spec/enums/as_return_optional.graphql
+++ b/spec/enums/as_return_optional.graphql
@@ -1,23 +1,15 @@
 "A Boolean Value"
 scalar Boolean
 
-type Droid {
-  primaryFunction: String!
-}
-
-"List of starwars episodes"
+"List of Starwars episodes"
 enum Episode {
-  IV
-  V
-  VI
+  EMPIRE
+  JEDI
+  NEWHOPE
 }
 
 "A Floating Point Number"
 scalar Float
-
-type Human {
-  homePlanet: String
-}
 
 "An ID"
 scalar ID
@@ -26,15 +18,7 @@ scalar ID
 scalar Int
 
 type Query {
-  droid(id: String!): Droid
-
-  "Get hero for episode"
-  hero(
-    "The episode"
-    episode: Episode!
-  ): Human!
-  human(id: String!): Human
-  humans: [Human!]!
+  aEpisode: Episode!
 }
 
 "A String Value"

--- a/spec/enums/as_return_optional_spec.cr
+++ b/spec/enums/as_return_optional_spec.cr
@@ -1,0 +1,31 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsReturnOptional
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def a_episode : Episode
+      Episode::NEWHOPE
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema" do
+    got = GraphQL::Schema.new(TestEnumsAsReturnOptional::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_return.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+end

--- a/spec/enums/as_return_spec.cr
+++ b/spec/enums/as_return_spec.cr
@@ -1,0 +1,45 @@
+require "spec"
+require "../../src/graphql"
+
+module TestEnumsAsReturn
+  @[GraphQL::Enum(description: "List of Starwars episodes")]
+  enum Episode
+    NEWHOPE
+    EMPIRE
+    JEDI
+  end
+
+  @[GraphQL::Object]
+  class Query
+    include GraphQL::ObjectType
+    include GraphQL::QueryType
+
+    @[GraphQL::Field]
+    def a_episode : Episode
+      Episode::NEWHOPE
+    end
+  end
+end
+
+describe GraphQL::Enum do
+  it "Enums generates correct schema" do
+    got = GraphQL::Schema.new(TestEnumsAsReturn::Query.new).document.to_s.strip
+    expected = {{ read_file("spec/enums/as_return.graphql") }}.strip
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+
+  it "returns the correct value" do
+    GraphQL::Schema.new(TestEnumsAsReturn::Query.new).execute(
+      %(
+        query { aEpisode }
+      )
+    ).should eq (
+      {
+        "data" => {
+          "aEpisode" => "NEWHOPE",
+        },
+      }
+    ).to_json
+  end
+end

--- a/spec/fixtures/star_wars.cr
+++ b/spec/fixtures/star_wars.cr
@@ -49,7 +49,7 @@ module StarWars
     ),
   ] of Human | Droid
 
-  @[GraphQL::Enum]
+  @[GraphQL::Enum(description: "List of starwars episodes")]
   enum Episode
     IV
     V
@@ -123,7 +123,7 @@ module StarWars
       episode: {description: "The episode"},
     })]
     def hero(episode : Episode) : Human
-      CHARACTERS.first
+      humans.first
     end
 
     @[GraphQL::Field]

--- a/src/graphql/document.cr
+++ b/src/graphql/document.cr
@@ -6,7 +6,7 @@ module GraphQL::Document
       def _graphql_document
         {% raise "GraphQL: #{@type.id} does not have a GraphQL::Object annotation" unless @type.annotation(::GraphQL::Object) %}
         {% objects = [@type, ::GraphQL::Introspection::Schema] %}
-        {% enums = [] of TypeNode %}
+        {% enums = [] of TypeNode %} 
         {% scalars = [] of TypeNode %}
 
         {% for i in (0..1000) %}
@@ -17,8 +17,18 @@ module GraphQL::Document
               {% end %}
               {% for arg in method.args %}
                 {% for type in arg.restriction.resolve.union_types %}
+                  {% if type.resolve < Array %}
+                    {% for inner_type in type.resolve.type_vars %}
+                      {% if inner_type.resolve.annotation(::GraphQL::Enum) && !enums.includes?(inner_type.resolve) %}
+                        {% enums << inner_type.resolve %}
+                      {% end %}
+                    {% end %}
+                  {% end %}
                   {% if type.resolve.annotation(::GraphQL::InputObject) && !objects.includes?(type.resolve) && !(type.resolve < ::GraphQL::Context) %}
                     {% objects << type.resolve %}
+                  {% end %}
+                  {% if type.resolve.annotation(::GraphQL::Enum) && !enums.includes?(type.resolve) %}
+                    {% enums << type.resolve %}
                   {% end %}
                   {% for inner_type in type.type_vars %}
                     {% if inner_type.resolve.annotation(::GraphQL::InputObject) && !objects.includes?(inner_type.resolve) && !(inner_type.resolve < ::GraphQL::Context) %}

--- a/src/graphql/object_type.cr
+++ b/src/graphql/object_type.cr
@@ -103,6 +103,9 @@ module GraphQL::ObjectType
                   {% elsif type < Int %}
                   when Int
                     arg_value.as({{type.id}})
+                  {% elsif type.annotation(::GraphQL::Enum) %}
+                  when ::GraphQL::Language::AEnum
+                    {{type.id}}.parse(arg_value.to_value)
                   {% elsif type.annotation(::GraphQL::InputObject) %}
                   when ::GraphQL::Language::InputObject
                     {{type.id}}._graphql_new(arg_value)
@@ -117,6 +120,9 @@ module GraphQL::ObjectType
                       {% elsif inner_type < Int %}
                       when Int
                         value.as({{inner_type.id}})
+                      {% elsif inner_type.annotation(::GraphQL::Enum) %}
+                      when ::GraphQL::Language::AEnum
+                        {{inner_type.id}}.parse(value.to_value)
                       {% elsif inner_type.annotation(::GraphQL::InputObject) %}
                       when ::GraphQL::Language::InputObject
                         {{inner_type.id}}._graphql_new(value)

--- a/src/graphql/object_type.cr
+++ b/src/graphql/object_type.cr
@@ -106,6 +106,8 @@ module GraphQL::ObjectType
                   {% elsif type.annotation(::GraphQL::Enum) %}
                   when ::GraphQL::Language::AEnum
                     {{type.id}}.parse(arg_value.to_value)
+                  when String
+                    {{type.id}}.parse(arg_value)
                   {% elsif type.annotation(::GraphQL::InputObject) %}
                   when ::GraphQL::Language::InputObject
                     {{type.id}}._graphql_new(arg_value)
@@ -123,6 +125,8 @@ module GraphQL::ObjectType
                       {% elsif inner_type.annotation(::GraphQL::Enum) %}
                       when ::GraphQL::Language::AEnum
                         {{inner_type.id}}.parse(value.to_value)
+                      when String
+                        {{inner_type.id}}.parse(value)
                       {% elsif inner_type.annotation(::GraphQL::InputObject) %}
                       when ::GraphQL::Language::InputObject
                         {{inner_type.id}}._graphql_new(value)
@@ -137,9 +141,9 @@ module GraphQL::ObjectType
                     end
                   {% end %}
                   when {{type.id}}
-                    arg_value
+                    arg_value                    
                   else
-                    return [GraphQL::Error.new("wrong type for argument {{ arg.name.id.camelcase(lower: true) }}", path)]
+                    return [GraphQL::Error.new("#{arg_value} is wrong type for argument {{ arg.name.id.camelcase(lower: true) }}", path)]
                   end
                 rescue TypeCastError
                   return [GraphQL::Error.new("wrong type for argument {{ arg.name.id.camelcase(lower: true) }}", path)]


### PR DESCRIPTION
Fixes enums as arguments and field return values.
fixes  #2 

It should allow all the following

```graphql
"List of Starwars episodes"
enum Episode {
  EMPIRE
  JEDI
  NEWHOPE
}

type Query {
  episodeToString(episode: Episode): String
  episodesToString(episodes: [Episode!]!): String!
  episodes: [Episode!]!
  aEpisode: Episode!
  ## etc
}
```