### PR TITLE
allow passing an io to Schema#execute

### DIFF
--- a/spec/star_wars_spec.cr
+++ b/spec/star_wars_spec.cr
@@ -48,4 +48,29 @@ describe StarWars::Query do
       }
     ).to_json
   end
+
+  it "Allows passing an io to render json to it" do
+    result = String.build do |io|
+      GraphQL::Schema.new(StarWars::Query.new).execute(
+        io,
+        %(
+            {
+              luke: human(id: "1000") {
+                name
+              }
+            }
+        )
+      )
+    end
+
+    result.should eq (
+      {
+        "data" => {
+          "luke" => {
+            "name" => "Luke Skywalker",
+          },
+        },
+      }
+    ).to_json
+  end
 end

--- a/src/graphql/schema.cr
+++ b/src/graphql/schema.cr
@@ -76,7 +76,13 @@ module GraphQL
       end
     end
 
-    def execute(query : String, variables : Hash(String, JSON::Any)? = nil, operation_name : String? = nil, context = Context.new)
+    def execute(query : String, variables : Hash(String, JSON::Any)? = nil, operation_name : String? = nil, context = Context.new): String
+      String.build do |io|
+        execute(io, query, variables, operation_name, context)
+      end
+    end
+
+    def execute(io : IO, query : String, variables : Hash(String, JSON::Any)? = nil, operation_name : String? = nil, context = Context.new): Nil
       document = Language.parse(query)
       operations = [] of Language::OperationDefinition
       errors = [] of GraphQL::Error
@@ -114,7 +120,7 @@ module GraphQL
                     end
                   end
 
-      JSON.build do |json|
+      JSON.build(io) do |json|
         json.object do
           if !operation.nil? && operation.operation_type == "query"
             json.field "data" do


### PR DESCRIPTION
this enables rendering very large responses directly to a socket without allocating a lot of memory