### PR TITLE
Fix context passing

### DIFF
--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -1,0 +1,41 @@
+require "./spec_helper"
+
+module ContextApi
+  @[GraphQL::Object]
+  class Query < GraphQL::BaseQuery
+    @[GraphQL::Field]
+    def value(ctx : Context) : Int32
+      ctx.value
+    end
+  end
+
+  class Context < GraphQL::Context
+    getter value : Int32
+
+    def initialize(@value)
+    end
+  end
+end
+
+describe GraphQL::Context do
+  it "returns value from context" do
+    value = 1337
+
+    ctx = ContextApi::Context.new(value)
+    schema = GraphQL::Schema.new(ContextApi::Query.new)
+
+    query = %(
+      {
+        value
+      }
+    )
+
+    schema.execute(query, context: ctx).should eq (
+      {
+        "data" => {
+          "value" => value,
+        },
+      }
+    ).to_json
+  end
+end

--- a/src/graphql/document.cr
+++ b/src/graphql/document.cr
@@ -145,13 +145,17 @@ module GraphQL::Document
 
             %input_values = [] of ::GraphQL::Language::InputValueDefinition
             {% for arg in method.args %}
-            %input_values << (_graphql_input_def(
-              {{ arg.restriction.resolve.union_types.find { |t| t != Nil } }},
-              {{ arg.restriction.resolve.nilable? }},
-              {{ arg.default_value.is_a?(Nop) ? nil : arg.default_value }},
-              {{ method.annotation(::GraphQL::Field)["arguments"] && method.annotation(::GraphQL::Field)["arguments"][arg.name.id] && method.annotation(::GraphQL::Field)["arguments"][arg.name.id]["name"] || arg.name.id.stringify.camelcase(lower: true) }},
-              {{ method.annotation(::GraphQL::Field)["arguments"] && method.annotation(::GraphQL::Field)["arguments"][arg.name.id] && method.annotation(::GraphQL::Field)["arguments"][arg.name.id]["description"] || nil }},
-            ))
+              {%
+                ann_args = method.annotation(::GraphQL::Field)["arguments"]
+                ann_arg = ann_args && ann_args[arg.name.id]
+              %}
+              %input_values << (_graphql_input_def(
+                {{ arg.restriction.resolve.union_types.find { |t| t != Nil } }},
+                {{ arg.restriction.resolve.nilable? }},
+                {{ arg.default_value.is_a?(Nop) ? nil : arg.default_value }},
+                {{ ann_arg && ann_arg["name"] || arg.name.id.stringify.camelcase(lower: true) }},
+                {{ ann_arg && ann_arg["description"] || nil }},
+              ))
             {% end %}
 
             {%

--- a/src/graphql/document.cr
+++ b/src/graphql/document.cr
@@ -145,17 +145,19 @@ module GraphQL::Document
 
             %input_values = [] of ::GraphQL::Language::InputValueDefinition
             {% for arg in method.args %}
-              {%
-                ann_args = method.annotation(::GraphQL::Field)["arguments"]
-                ann_arg = ann_args && ann_args[arg.name.id]
-              %}
-              %input_values << (_graphql_input_def(
-                {{ arg.restriction.resolve.union_types.find { |t| t != Nil } }},
-                {{ arg.restriction.resolve.nilable? }},
-                {{ arg.default_value.is_a?(Nop) ? nil : arg.default_value }},
-                {{ ann_arg && ann_arg["name"] || arg.name.id.stringify.camelcase(lower: true) }},
-                {{ ann_arg && ann_arg["description"] || nil }},
-              ))
+              {% unless arg.restriction.resolve < ::GraphQL::Context %}
+                {%
+                  ann_args = method.annotation(::GraphQL::Field)["arguments"]
+                  ann_arg = ann_args && ann_args[arg.name.id]
+                %}
+                %input_values << (_graphql_input_def(
+                  {{ arg.restriction.resolve.union_types.find { |t| t != Nil } }},
+                  {{ arg.restriction.resolve.nilable? }},
+                  {{ arg.default_value.is_a?(Nop) ? nil : arg.default_value }},
+                  {{ ann_arg && ann_arg["name"] || arg.name.id.stringify.camelcase(lower: true) }},
+                  {{ ann_arg && ann_arg["description"] || nil }},
+                ))
+              {% end %}
             {% end %}
 
             {%

--- a/src/graphql/internal/convert_value.cr
+++ b/src/graphql/internal/convert_value.cr
@@ -7,7 +7,7 @@ module GraphQL::Internal
     {% if type == Float64 %}
     when Int32
       %value.to_f64.as({{type}})
-    {% elsif type.resolve.annotation(::GraphQL::Enum) %}
+    {% elsif type.annotation(::GraphQL::Enum) %}
     when ::GraphQL::Language::AEnum
       {{type}}.parse(%value.to_value)
     when String


### PR DESCRIPTION
Passing a context leads to the following compilation error:

```
 > 16 |               
 > 17 |                 
 > 18 |                 __temp_126 << (_graphql_input_def(
                                       ^
Error: GraphQL: type ContextApi::Context is not a GraphQL type
```

This PR:
- adds a failing test case
- fixes the issue by adding an unless that skips parameters of type Contexts since the error is caused by the loop in `document.cr` (as far as i understand it)
- extracts a few common sub-expressions to shorten the lines
- removes a `.resolve` that seems unnecessary

