### PR TITLE
Concurrent Resolving

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -8,6 +8,13 @@ describe GraphQL::Introspection do
     got.should eq expected
   end
 
+  it "returns a hash when execute_to_hash is called" do
+    got = GraphQL::Schema.new(QueryFixture::Query.new).execute_to_hash(GraphQL::INTROSPECTION_QUERY)
+    expected = JSON.parse({{ read_file "spec/fixtures/query_introspection.json" }})
+    puts "\n====================\n#{got}\n====================" if got != expected
+    got.should eq expected
+  end
+
   it "resolves nested input object with various value types" do
     GraphQL::Schema.new(QueryFixture::Query.new).execute(
       %(

--- a/src/graphql/query_type.cr
+++ b/src/graphql/query_type.cr
@@ -1,8 +1,15 @@
+require "./annotations"
+
 module GraphQL::QueryType
   macro included
     macro finished
       include ::GraphQL::Document
     end
+  end
+
+  @[GraphQL::Field(name: "__schema")]
+  def _schema(context : ::GraphQL::Context) : GraphQL::Introspection::Schema
+    ::GraphQL::Introspection::Schema.new(context.document.not_nil!, _graphql_type, context.mutation_type)
   end
 end
 

--- a/src/graphql/schema.cr
+++ b/src/graphql/schema.cr
@@ -126,19 +126,21 @@ module GraphQL
                     end
                   end
 
-      data = nil
+      result = ObjectType::ResolveResult.new(nil)
 
       if !operation.nil? && operation.operation_type == "query"
-        query_errors, data = @query._graphql_resolve(context, operation.selections)
-        errors.concat query_errors
+        result = @query._graphql_resolve(context, operation.selections)
+        errors.concat result.errors
       elsif !operation.nil? && operation.operation_type == "mutation"
         if mutation = @mutation
-          mutation_errors, data = mutation._graphql_resolve(context, operation.selections)
-          errors.concat mutation_errors
+          result = mutation._graphql_resolve(context, operation.selections)
+          errors.concat result.errors
         else
           errors << Error.new("mutation operations are not supported", [] of String | Int32)
         end
       end
+
+      data = result.data
 
       if errors.empty?
         { "data" => data }


### PR DESCRIPTION
First of all: Thank you so much for this awesome shard! :heart:

I started a project using this shard and I thought I could try to contribute to bring it another step forward.

This PR does to things (i can split this up into two PRs if you like)

1. It separates the concerns of resolving and serializing. `_graphql_resolve` on an ObjectType now returns a `ResolveResult` containing the data as a Hash and any errors (like the return value of `_graphql_resolve` did before this change). `Schema#execute` now calls `Schema#execute_to_hash(...).to_json(io)`. I deliberately didn't change the return type of  `Schema#execute` to maintain backwards compatibility.
2. Building on the Hash part it was now possible to resolve object fields and array members concurrently so that's what I did. The reasoning for this is that you don't block on a single long running (database call) field resolver. Even better: it opens the door for using dataloaders to mitigate N+1 queries!

Regarding dataloaders: I did a test implementation for an abstract DataLoader class and it was just about 100 LOC. Nothing too complicated. Although you could argue dataloaders can be used anywhere I think this would still be best located in this shard. The javascript dataloader implementation is also under the organization graphql. What do you think? Here's the implementation with a simple example: https://p.jokke.space/m-9PYZs